### PR TITLE
Update dockerization without entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,13 @@ COPY .docker/nginx.conf /etc/nginx/nginx.conf
 # Copy our custom nginx config
 COPY .docker/config.js.template /etc/nginx/config.js.template
 
+# Add bash
+RUN apk add --no-cache bash
+
 # from the outside.
 EXPOSE 80
 
 COPY .docker/docker-entrypoint.sh /
-ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["nginx", "-g", "daemon off;"]
+RUN chmod +x docker-entrypoint.sh
+CMD ["/bin/bash", "-c", "/docker-entrypoint.sh && nginx -g \"daemon off;\""]
 


### PR DESCRIPTION
Resource link: https://www.freecodecamp.org/news/how-to-implement-runtime-environment-variables-with-create-react-app-docker-and-nginx-7f9d42a91d70/

In TermitUI, according to the [doc](https://github.com/kbss-cvut/termit-ui/blob/master/doc/setup.md), environment variables are passed at build time, not runtime